### PR TITLE
Maestro Interface updates

### DIFF
--- a/src/maestro.ts
+++ b/src/maestro.ts
@@ -1,6 +1,6 @@
 import {IClassifier, IDataEmitter, IDisposable} from "./dataEmitter";
 import {IChronicler} from "./chronicler";
-import { IDisposableAsync } from "./lib";
+import { IChroniclerDescription, IDisposableAsync, IEmitterDescription } from "./lib";
 
 /**
  * Methods to start and stop a service,
@@ -44,17 +44,21 @@ export function isService(obj: unknown) : boolean {
 export interface IEmitterMaestro {
     /**
      * Add a emitter to the collection of
-     * emitters managed by the maestro
+     * emitters managed by the maestro, either from
+     * an existing instance or provide a description
+     * and the maestro will create the emitter if a factory is available
      * @param {IDataEmitter} emitter
      */
-    addEmitter(emitter:IDataEmitter): void;
+    addEmitter(emitter:IDataEmitter|IEmitterDescription): Promise<void>;
 
     /**
      * Remove a emitter from the collection of
-     * emitters managed by the maestro
-     * @param {IDataEmitter} emitter
+     * emitters managed by the maestro, identified
+     * either by providing the emitter instance
+     * or the unique emitter id
+     * @param {IDataEmitter|string} emitter
      */
-    removeEmitter(emitter:IDataEmitter): void;
+    removeEmitter(emitter:IDataEmitter|string): Promise<void>;
 
     /**
      * Collection of emitters maintained by the maestro
@@ -68,17 +72,20 @@ export interface IEmitterMaestro {
 export interface  IChroniclerMaestro {
     /**
      * Add a chronicler to the collection of
-     * chroniclers managed by the maestro
-     * @param {IChronicler} chronicler
+     * chroniclers managed by the maestro, this can be an
+     * existing instance or a description and the maestro 
+     * will attempt to create the chronicler from available facotires
+     * @param {IChronicler|IChroniclerDescription} chronicler
      */
-    addChronicler(chronicler:IChronicler): void;
+    addChronicler(chronicler:IChronicler|IChroniclerDescription): Promise<void>;
 
     /**
      * Remove a chronicler from the collection of
-     * chroniclers managed by the maestro
-     * @param {IChronicler} chronicler
+     * chroniclers managed by the maestro, this can either be the 
+     * chronicler instance or unique chronicler id
+     * @param {IChronicler|string} chronicler
      */
-    removeChronicler(chronicler:IChronicler): void;
+    removeChronicler(chronicler:IChronicler|string): Promise<void>;
 
     /**
      * Collection of chroniclers maintained by the maestro
@@ -89,7 +96,7 @@ export interface  IChroniclerMaestro {
 /**
  * Maestro that connects and manages instances of {IDataEmitter} and {IChronicler}
  */
-export interface IMaestro extends IEmitterMaestro, IChroniclerMaestro, IClassifier, IDisposableAsync {
+export interface IMaestro extends IEmitterMaestro, IChroniclerMaestro, IClassifier, IService, IDisposableAsync {
     /**
      * connect the collection of emitters to the collection of chroniclers,
      * each emitter will save it's records to each of the chroniclers


### PR DESCRIPTION
- sets maestro to extend IService 
- updates add/remove methods for maestro to accept description objects and ids in addition to the existing chronicler/emitter instance signature.