### PR TITLE
Adds emitter property to the status event

### DIFF
--- a/src/baseEmitter.ts
+++ b/src/baseEmitter.ts
@@ -10,6 +10,7 @@ import { IJsonSerializable, isJsonSerializable } from "./chronicler";
  * 
  */
 export class BaseStatusEvent implements IStatusEvent {
+    emitter: IDataEmitter;
     connected: boolean;
     bit: boolean;
     timestamp: Date;
@@ -18,11 +19,13 @@ export class BaseStatusEvent implements IStatusEvent {
      * 
      * @param {boolean} connected 
      * @param {boolean} bit 
+     * @param {IDataEmitter} emitter
      * @param {Date} timestamp 
      */
-    constructor(connected: boolean, bit: boolean, timestamp?: Date) {
+    constructor(connected: boolean, bit: boolean, emitter: IDataEmitter, timestamp?: Date) {
         this.connected = connected;
         this.bit = bit;
+        this.emitter = emitter;
         this.timestamp = timestamp || new Date();
     }
 
@@ -341,7 +344,7 @@ export abstract class BaseEmitter implements IDataEmitter, IDisposable {
      * @return {IStatusEvent} 
      */
     protected buildStatusEvent(): IStatusEvent {
-        return new BaseStatusEvent(this._connected, this._faulted);
+        return new BaseStatusEvent(this._connected, this._faulted, this);
     }
 
     /**

--- a/src/dataEmitter.ts
+++ b/src/dataEmitter.ts
@@ -65,14 +65,17 @@ export interface IExecutionResult extends ITraceableAction {
      record.data != null && record.meta != null;
 }
 
+export interface IEmitterEvent extends IJsonSerializable {
+    /**
+     * Source of the event
+     */
+    readonly emitter: IDataEmitter;
+}
+
 /**
  * A data emission event
  */
-export interface IDataEvent extends IJsonSerializable {
-    /**
-     *  Source of the event
-     */
-    readonly emitter: IDataEmitter;
+export interface IDataEvent extends IEmitterEvent {
     /**
      * Time of data event
      */
@@ -101,7 +104,8 @@ export function isStatusEvent(obj: unknown) : boolean {
 /**
  * A status event, this include information about connection status changes, built in test failures (BIT) etc
  */
-export interface IStatusEvent extends IJsonSerializable {
+export interface IStatusEvent extends IEmitterEvent {
+
     /**
      * source connection state
      */

--- a/test/helpers/testEmitter.ts
+++ b/test/helpers/testEmitter.ts
@@ -2,6 +2,7 @@ import { BaseEmitter, BaseStatusEvent } from "../../src/baseEmitter";
 import { ICommand, IExecutionResult, IStatusEvent, IDataEvent, IDataEmitter, IEmitterDescription } from "../../src/dataEmitter";
 import { ProviderSingleton } from "../../src/provider";
 import { BaseEmitterFactory } from "../../src/factory";
+import { LoggerFacade } from "../../src/loggerFacade";
 
 /**
  * 
@@ -17,13 +18,25 @@ export class TestEmitter extends BaseEmitter {
         actionId: "n/a"
     };
 
-    public statusEvent: IStatusEvent = new BaseStatusEvent(false, true);
+    public statusEvent: IStatusEvent;
 
     public dataEvent: IDataEvent|undefined;
 
     public metaData: unknown = {
 
     };
+
+    /**
+     * Test Data Emitter\
+     * @param {string} id
+     * @param {string} name
+     * @param {string} desc
+     * @param {LoggerFacade|undefined} logger
+     */
+    constructor(id: string, name: string, desc: string, logger?: LoggerFacade) {
+        super(id, name, desc, logger);
+        this.statusEvent = new BaseStatusEvent(false, true, this);
+    }
 
     /**
      * 


### PR DESCRIPTION
Adds the emitter property to the status event so status events can easily be attributed to an emitter when saving records in the sql chronicler. 